### PR TITLE
Nat44: Create entry type & improvements

### DIFF
--- a/types/addr.go
+++ b/types/addr.go
@@ -53,3 +53,20 @@ func ToVppIPProto(proto IPProto) uint8 {
 		return ^uint8(0)
 	}
 }
+
+func formatProto(proto IPProto) string {
+	switch proto {
+	case UDP:
+		return "UDP"
+	case TCP:
+		return "TCP"
+	case SCTP:
+		return "SCTP"
+	case ICMP:
+		return "ICMP"
+	case ICMP6:
+		return "ICMP6"
+	default:
+		return "???"
+	}
+}

--- a/types/nat.go
+++ b/types/nat.go
@@ -16,6 +16,8 @@
 package types
 
 import (
+	"fmt"
+	"net"
 	vppnat "github.com/calico-vpp/vpplink/binapi/20.05-rc0~540-gad1cca49e/nat"
 )
 
@@ -35,4 +37,22 @@ const (
 
 func ToVppNatConfigFlags(flags NatFlags) vppnat.NatConfigFlags {
 	return vppnat.NatConfigFlags(flags)
+}
+
+type Nat44Entry struct {
+	ServiceIP       net.IP
+	ServicePort     int32
+	Protocol        IPProto
+	BackendIPs      []net.IP
+	BackendPort     int32
+}
+
+func (n *Nat44Entry) String() string {
+	return fmt.Sprintf("%s %s:%d -> %+v:%d",
+		formatProto(n.Protocol),
+		n.ServiceIP.String(),
+		n.ServicePort,
+		n.BackendIPs,
+		n.BackendPort,
+	)
 }


### PR DESCRIPTION
* Make a nat44 LB/1:1 mapping a struct
* Pass net.IP parameters and not strings
* Add/DelLBEntry don't error when len(backend) == 0

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>